### PR TITLE
Fix that won't fail except for specific errors that can be resolved

### DIFF
--- a/lib/fastlane/plugin/mackerel_actions/actions/mackerel_post_duration.rb
+++ b/lib/fastlane/plugin/mackerel_actions/actions/mackerel_post_duration.rb
@@ -25,7 +25,28 @@ module Fastlane
               "time" => now,
               "value" => duration
             }
-          ]
+          ],
+          error_handlers: {
+            403 => proc do |response|
+              UI.error("Forbidden")
+              UI.user_error!("Mackerel responded with #{response[:status]}\n---\n#{response[:body]}")
+            end,
+            404 => proc do |response|
+              UI.error("Something went wrong - I couldn\'t find it...")
+              UI.user_error!("Mackerel responded with #{response[:status]}\n---\n#{response[:body]}")
+            end,
+            429 => proc do |response|
+              UI.error("Too Many Requests")
+              UI.user_error!("Mackerel responded with #{response[:status]}\n---\n#{response[:body]}")
+            end,
+            503 => proc do |response|
+              UI.message("Mackerel is under maintenance.")
+              UI.message("Mackerel responded with #{response[:status]}\n---\n#{response[:body]}")
+            end,
+            '*' => proc do |response|
+              UI.message("Handle all error codes other")
+            end
+          }
         )
 
         UI.message(result)

--- a/lib/fastlane/plugin/mackerel_actions/actions/mackerel_post_xcresult.rb
+++ b/lib/fastlane/plugin/mackerel_actions/actions/mackerel_post_xcresult.rb
@@ -28,7 +28,28 @@ module Fastlane
           api_key: params[:api_key],
           http_method: "POST",
           path: "api/v0/services/#{params[:service_name]}/tsdb",
-          body: body
+          body: body,
+          error_handlers: {
+            403 => proc do |response|
+              UI.error("Forbidden")
+              UI.user_error!("Mackerel responded with #{response[:status]}\n---\n#{response[:body]}")
+            end,
+            404 => proc do |response|
+              UI.error("Something went wrong - I couldn\'t find it...")
+              UI.user_error!("Mackerel responded with #{response[:status]}\n---\n#{response[:body]}")
+            end,
+            429 => proc do |response|
+              UI.error("Too Many Requests")
+              UI.user_error!("Mackerel responded with #{response[:status]}\n---\n#{response[:body]}")
+            end,
+            503 => proc do |response|
+              UI.message("Mackerel is under maintenance.")
+              UI.message("Mackerel responded with #{response[:status]}\n---\n#{response[:body]}")
+            end,
+            '*' => proc do |response|
+              UI.message("Handle all error codes other")
+            end
+          }
         )
 
         UI.message(result)


### PR DESCRIPTION
I changed to do not fail except for certain errors that can be resolved.

API specipfic errors: https://mackerel.io/api-docs/entry/service-metrics#post